### PR TITLE
Fix for entry_with_uuid_exists? method, added "url" property

### DIFF
--- a/lib/agcaldav/client.rb
+++ b/lib/agcaldav/client.rb
@@ -301,6 +301,7 @@ module AgCalDAV
       	
       }
       begin
+        errorhandling res
       	Icalendar.parse(res.body)
       rescue
       	return false

--- a/lib/agcaldav/client.rb
+++ b/lib/agcaldav/client.rb
@@ -150,8 +150,8 @@ module AgCalDAV
         dtstart       DateTime.parse(event[:start])
         dtend         DateTime.parse(event[:end])
         categories    event[:categories]# Array
-        contacts       event[:contacts] # Array
-        attendees      event[:attendees]# Array
+        contacts      event[:contacts] # Array
+        attendees     event[:attendees]# Array
         duration      event[:duration]
         summary       event[:title]
         description   event[:description]
@@ -159,6 +159,7 @@ module AgCalDAV
         location      event[:location]
         geo_location  event[:geo_location]
         status        event[:status]
+        url           event[:url]
       end
       cstring = c.to_ical
       res = nil

--- a/lib/agcaldav/client.rb
+++ b/lib/agcaldav/client.rb
@@ -133,7 +133,8 @@ module AgCalDAV
         res = http.request( req )
       }
       errorhandling res
-      if res.code.to_i == 200
+      # accept any success code
+      if res.code.to_i.between?(200,299)
         return true
       else
         return false


### PR DESCRIPTION
Hi,

i could not get the lib to work with radicale server, it suddenly stopped creating events throwing DuplicateErrors. After some digging I narrowed the source of the error down to the Icalendar.parse-call in the entry_with_uuid_exists? method in lib/agcaldav/client.rb, which returns an empty array if the preceding request returns an HTTP Error 410.

I've also added the 'url' property to create_event.

Thanks in advance!
