### PR TITLE
bugfix gemspec, icalender dependency on version 1.5

### DIFF
--- a/agcaldav.gemspec
+++ b/agcaldav.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage    = %q{https://github.com/agilastic/agcaldav}
   s.authors     = [%q{Alex Ebeling-Hoppe}]
   s.email       = [%q{ebeling-hoppe@agilastic.de}]
-  s.add_runtime_dependency 'icalendar'
+  s.add_runtime_dependency 'icalendar', '~>1.5'
   s.add_runtime_dependency 'uuid'
   s.add_runtime_dependency 'builder'
   s.add_runtime_dependency 'net-http-digest_auth'


### PR DESCRIPTION
there is a dependency to icalendar 1.5 that make agcaldav fail with icalendar 2.x.
updated gemspec accordingly
